### PR TITLE
Added ability to use getblock and setblock with schematic coordinates

### DIFF
--- a/litemapy/schematic.py
+++ b/litemapy/schematic.py
@@ -248,18 +248,22 @@ class Region:
         root["BlockStates"] = arr._tonbtlongarray()
         return root
 
-    def getblock(self, x, y, z):
+    def getblock(self, x, y, z, schem=False):
         """
         Return the block at the given coordinates
+        If schem = True, will use schematic coordinates
         """
-        x, y, z = self.__regcoordinates2storecoords(x, y, z)
+        if not schem:
+            x, y, z = self.__regcoordinates2storecoords(x, y, z)
         return self.__palette[self.__blocks[x, y, z]]
 
-    def setblock(self, x, y, z, block):
+    def setblock(self, x, y, z, block, schem=False):
         """
         Set the block at the given coordinate
+        If schem = True, will use schematic coordinates
         """
-        x, y, z = self.__regcoordinates2storecoords(x, y, z)
+        if not schem:
+            x, y, z = self.__regcoordinates2storecoords(x, y, z)
         if block in self.__palette:
             i = self.__palette.index(block)
         else:


### PR DESCRIPTION
In my project, I like to work purely in the positive coordinate space for my own sanity. By using the schematic's coordinate system, I can do this easily.
Other reasonable future changes might be to add range functions for schematic coordinates as well.