### PR TITLE
Added support to read (tile) entities

### DIFF
--- a/litemapy/schematic.py
+++ b/litemapy/schematic.py
@@ -550,13 +550,13 @@ class Entity:
     def __init__(self, str_or_nbt):
 
         if isinstance(str_or_nbt, str):
-            self._data = List(Compound)([Compound({'id': String(str_or_nbt)})])
+            self._data = Compound({'id': String(str_or_nbt)})
         else:
             self._data = str_or_nbt
 
         keys = self._data.keys()
         if 'id' not in keys:
-            self._data['id'] = String('minecraft:empty')
+            raise RequiredKeyMissingException('id')
         if 'Pos' not in keys:
             self._data['Pos'] = List[Double]([Double(0.), Double(0.), Double(0.)])
         if 'Rotation' not in keys:
@@ -646,13 +646,13 @@ class TileEntity:
     def __init__(self, str_or_nbt):
 
         if isinstance(str_or_nbt, str):
-            self._data = List(Compound)([Compound({'id': String(str_or_nbt)})])
+            self._data = Compound({'id': String(str_or_nbt)})
         else:
             self._data = str_or_nbt
 
         keys = self._data.keys()
         if 'id' not in keys:
-            self._data['id'] = String('minecraft:empty')
+            raise RequiredKeyMissingException('id')
         if 'x' not in keys:
             self._data['x'] = Int(0)
         if 'y' not in keys:
@@ -723,3 +723,14 @@ AIR = BlockState("minecraft:air")
 
 class CorruptedSchematicError(Exception):
     pass
+
+
+class RequiredKeyMissingException(Exception):
+
+    def __init__(self, key, message='The required key is missing in the (Tile)Entity\'s NBT Compound'):
+        self.key = key
+        self.message = message
+        super().__init__(self.message)
+
+    def __str__(self):
+        return f'{self.key} -> {self.message}'

--- a/litemapy/schematic.py
+++ b/litemapy/schematic.py
@@ -124,7 +124,6 @@ class Schematic:
         fname: name of the file
         """
         nbt = nbtlib.File.load(fname, True)
-        # print(nbt)
         return Schematic.fromnbt(nbt)
 
     def _can_add_region(self, name, region):
@@ -210,8 +209,9 @@ class Schematic:
     def preview(self):
         return self.__preview
 
-    def set_preview(self, preview):
-        self.__preview = preview
+    @preview.setter
+    def preview(self, value):
+        self.__preview = value
 
 
 class Region:
@@ -358,7 +358,6 @@ class Region:
                     reg.__blocks[x][y][z] = arr[ind]
 
         for blockTick in nbt["PendingBlockTicks"]:
-            print(blockTick)
             reg.blockTicks.append(blockTick)
 
         for fluidTick in nbt["PendingFluidTicks"]:


### PR DESCRIPTION
Added support to read (tile) entities and pending ticks from .litematic files. The pending ticks are simply kept as NBT tags. The entities get a wrapper class that allows the user to set and change some basic information like an entity's position.

The Entity and TileEntity classes are basically just wrappers for the NBT tag plus some functions to get and set basic properties that all entities have (Entity: id, Pos, Rotation, Motion; TileEntity: id, x, y, z).

The support for preview images and pending ticks is even more basic. The NBT tags are simply stored in a Region's member variables and wrote to file when saved.