### PR TITLE
expose all BlockState properties and allow passing them back in

### DIFF
--- a/litemapy/schematic.py
+++ b/litemapy/schematic.py
@@ -1041,6 +1041,15 @@ class BlockState:
         """
         return self.__blockid
 
+    @property
+    def properties(self):
+        """
+        The block's properties.
+
+        :type:  dict
+        """
+        return self.__properties
+
     def __validate(self, k, v):
         if type(k) is not str or type(v) is not str:
             return False, "Blockstate properties should be a string => string dictionary"

--- a/litemapy/storage.py
+++ b/litemapy/storage.py
@@ -114,7 +114,7 @@ class DiscriminatingDictionary(dict):
             self.onremove = options.pop("onremove")
         else:
             self.onremove = None
-        if len(args) == 1 and type(args[0]) == dict:
+        if len(args) == 1 and type(args[0]) in [dict, DiscriminatingDictionary]:
             for key, item in args[0].items():
                 self.validate(key, item)
             options = args[0]


### PR DESCRIPTION
e.g. I wanted to un-waterlog a load of blocks with other properties I wanted to keep, so with this change I could do
```python
props = b.properties
props['waterlogged'] = 'false'
newblock = BlockState(b.blockid, properties=props)
reg.setblock(x, y, z, newblock)
```