### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/docs/source/litematics.rst
+++ b/docs/source/litematics.rst
@@ -2,7 +2,7 @@ The Litematic file format
 =========================
 
 A Litematic file is made up of an NBT compound, and is basically just some metadata and a list of regions.
-The Litematic version and `Minecraft data version <https://minecraft.fandom.com/wiki/Data_version>`_
+The Litematic version and `Minecraft data version <https://minecraft.wiki/w/Data_version>`_
 are also stored at the root of the compound.
 In Litemapy, a litematic schematic is represented by the :class:`~litemapy.Schematic` class.
 

--- a/litemapy/info.py
+++ b/litemapy/info.py
@@ -1,6 +1,6 @@
 LITEMATIC_VERSION = 6  # Litematic version we are trying to imitate from Litematica (1.18.2-0.11.3)
 SPONGE_VERSION = 2  # Sponge format version used by WorldEdit (https://github.com/SpongePowered/Schematic-Specification)
-MC_DATA_VERSION = 2975  # Minecraft 1.18.2 (https://minecraft.fandom.com/wiki/Data_version)
+MC_DATA_VERSION = 2975  # Minecraft 1.18.2 (https://minecraft.wiki/w/Data_version)
 DEFAULT_NAME = "Unnamed"  # Default name given to schematics and regions if unspecified
 LITEMAPY_NAME = "Litemapy"  # Used to identify schematic created with Litemapy in metadata
 LITEMAPY_VERSION = "0.7.2b0"  # Unique version string

--- a/litemapy/schematic.py
+++ b/litemapy/schematic.py
@@ -377,7 +377,7 @@ class Region:
         for more information.
 
         :param mc_version:  Minecraft data version that is being emulated
-                            (https://minecraft.fandom.com/wiki/Data_version).
+                            (https://minecraft.wiki/w/Data_version).
                             Should not be critical for newer versions of Minecraft.
         :type mc_version:   int
         :param gzipped:     Whether the NBT Compound file should be compressed
@@ -545,7 +545,7 @@ class Region:
         Returns the Region as an NBT Compound file that conforms to Minecraft's structure NBT files.
 
         :param mc_version:  Minecraft data version that is being emulated
-                            (https://minecraft.fandom.com/wiki/Data_version).
+                            (https://minecraft.wiki/w/Data_version).
                             Should not be critical for newer versions of Minecraft.
         :type mc_version:   int
         :param gzipped:     Whether the NBT Compound file should be compressed


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki