### PR TITLE
Fix documentation compilation on Read The Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,3 +9,4 @@ python:
   install:
     - method: pip
       path: .
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-rtd-theme==2.0.0


### PR DESCRIPTION
Read The Docs no longer installs `sphinx-rtd-theme` by default in the docs build environment (see [their docs](https://blog.readthedocs.com/python-core-requirements-changed/)).

This makes it so the theme is explicitly installed using a dedicated `requirements.txt` file.