### PR TITLE
Enforce valid resource location names

### DIFF
--- a/tests/test_minecraft.py
+++ b/tests/test_minecraft.py
@@ -1,13 +1,31 @@
+import pytest
+
 from litemapy import BlockState
+from litemapy.minecraft import is_valid_identifier
+from litemapy.minecraft import InvalidIdentifier
+from litemapy.schematic import AIR
 
 
 def test_blockstate_initialization():
-    # TODO Split into multiple smaller tests
     prop = {"test1": "testval", "test2": "testval2"}
     b = BlockState("minecraft:stone", **prop)
     assert len(prop) == len(b)
     for k, v in prop.items():
         assert b[k] == v
+
+
+def test_cannot_create_blockstate_with_invalid_id():
+    ids = (
+        "",
+        "minecraft stone",
+        "stone",
+        "minecraft:stone[property=value]",
+    )
+    for id_ in ids:
+        with pytest.raises(InvalidIdentifier):
+            BlockState(id_, prop="val")
+        with pytest.raises(InvalidIdentifier):
+            AIR.with_id(id_)
 
 
 def test_blockstate_nbt_is_identity():
@@ -34,3 +52,16 @@ def test_blockstate_is_hashable():
     assert state1 == state2
     assert hash(state1) == hash(state2)
     assert hash(state1) == hash(state1)
+
+
+def test_is_valid_identifier():
+    assert is_valid_identifier("minecraft:air")
+    assert is_valid_identifier("minecraft:stone_cutter")
+    assert is_valid_identifier("terramap:path/is/allowed_slashes.png")
+    assert is_valid_identifier("weird.mod-id:both_are_allowed-dashes-and_underscores.and.dots")
+
+    assert not is_valid_identifier("")
+    assert not is_valid_identifier(" ")
+    assert not is_valid_identifier("minecraft:minecraft:stone")
+    assert not is_valid_identifier("minecraft:oak_stairs[facing=north]")
+    assert not is_valid_identifier("minecraft")


### PR DESCRIPTION
Fixes #49 .

Enforces BlockState and Entity have valid identifiers as defined in the game's `ResourceLocation` class.