### PR TITLE
Fix outdated documentation and internal deprecated method calls (Issue #60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ schem = Schematic.load("planet.litematic")
 reg = list(schem.regions.values())[0]
 
 # Print out the basic shape
-for x in reg.xrange():
-    for z in reg.zrange():
+for x in reg.range_x():
+    for z in reg.range_z():
         b = reg[x, 10, z]
         if b.id == "minecraft:air":
             print(" ", end="")

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -25,9 +25,9 @@ or how it plays with Litemapy.
     block = BlockState("minecraft:light_blue_concrete")
 
     # Build the planet
-    for x, y, z in reg.allblockpos():
+    for x, y, z in reg.block_positions():
         if round(((x-10)**2 + (y-10)**2 + (z-10)**2)**.5) <= 10:
-            reg.setblock(x, y, z, block)
+            reg[x, y, z] = block
 
     # Save the schematic
     schem.save("planet.litematic")
@@ -37,9 +37,9 @@ or how it plays with Litemapy.
     reg = list(schem.regions.values())[0]
 
     # Print out the basic shape
-    for x in reg.xrange():
-        for z in reg.zrange():
-            b = reg.getblock(x, 10, z)
+    for x in reg.range_x():
+        for z in reg.range_z():
+            b = reg[x, 10, z]
             if b.id == "minecraft:air":
                 print(" ", end="")
             else:

--- a/examples/filter.py
+++ b/examples/filter.py
@@ -86,7 +86,7 @@ def glacify_litematic(in_file: str, out_file: str):
         # Update the stats
         volume = region.volume()
         total_blocks += volume
-        print(f"Processing region {name} of volume {volume} blocks ({region.getblockcount()} non-air)")
+        print(f"Processing region {name} of volume {volume} blocks ({region.count_blocks()} non-air)")
 
         # This is where the magic happens: we ask Litemapy to replace blocks according to what glassiy returns
         region.filter(glassify)

--- a/litemapy/schematic.py
+++ b/litemapy/schematic.py
@@ -113,8 +113,8 @@ class Schematic:
         meta["RegionCount"] = Int(len(self.regions))
         meta["TimeCreated"] = Long(self.created)
         meta["TimeModified"] = Long(self.modified)
-        meta["TotalBlocks"] = Int(sum([reg.getblockcount() for reg in self.regions.values()]))
-        meta["TotalVolume"] = Int(sum([reg.getvolume() for reg in self.regions.values()]))
+        meta["TotalBlocks"] = Int(sum([reg.count_blocks() for reg in self.regions.values()]))
+        meta["TotalVolume"] = Int(sum([reg.volume() for reg in self.regions.values()]))
         meta['PreviewImageData'] = self.__preview
         root["Metadata"] = meta
         regs = Compound()
@@ -222,24 +222,24 @@ class Schematic:
             self.__z_max = max(self.__z_max, region.max_schem_z())
 
     def __on_region_remove(self, name, region) -> None:
-        bounding_box_changed: bool = self.__x_min == region.minschemx()
-        bounding_box_changed = bounding_box_changed or self.__x_max == region.maxschemx()
-        bounding_box_changed = bounding_box_changed or self.__y_min == region.minschemy()
-        bounding_box_changed = bounding_box_changed or self.__y_max == region.maxschemy()
-        bounding_box_changed = bounding_box_changed or self.__z_min == region.minschemz()
-        bounding_box_changed = bounding_box_changed or self.__z_max == region.maxschemz()
+        bounding_box_changed: bool = self.__x_min == region.min_schem_x()
+        bounding_box_changed = bounding_box_changed or self.__x_max == region.max_schem_x()
+        bounding_box_changed = bounding_box_changed or self.__y_min == region.min_schem_y()
+        bounding_box_changed = bounding_box_changed or self.__y_max == region.max_schem_y()
+        bounding_box_changed = bounding_box_changed or self.__z_min == region.min_schem_z()
+        bounding_box_changed = bounding_box_changed or self.__z_max == region.max_schem_z()
         if bounding_box_changed:
             self.__compute_enclosure()
 
     def __compute_enclosure(self):
         x_min, x_max, y_min, y_max, z_min, z_max = None, None, None, None, None, None
         for region in self.__regions.values():
-            x_min = min(x_min, region.minschemx()) if x_min is not None else region.minschemx()
-            x_max = max(x_max, region.maxschemx()) if x_max is not None else region.maxschemx()
-            y_min = min(y_min, region.minschemy()) if y_min is not None else region.minschemy()
-            y_max = max(y_max, region.maxschemy()) if y_max is not None else region.maxschemy()
-            z_min = min(z_min, region.minschemz()) if z_min is not None else region.minschemz()
-            z_max = max(z_max, region.maxschemz()) if z_max is not None else region.maxschemz()
+            x_min = min(x_min, region.min_schem_x()) if x_min is not None else region.min_schem_x()
+            x_max = max(x_max, region.max_schem_x()) if x_max is not None else region.max_schem_x()
+            y_min = min(y_min, region.min_schem_y()) if y_min is not None else region.min_schem_y()
+            y_max = max(y_max, region.max_schem_y()) if y_max is not None else region.max_schem_y()
+            z_min = min(z_min, region.min_schem_z()) if z_min is not None else region.min_schem_z()
+            z_max = max(z_max, region.max_schem_z()) if z_max is not None else region.max_schem_z()
         self.__x_min = x_min
         self.__x_max = x_max
         self.__y_min = y_min

--- a/tests/test_schematics.py
+++ b/tests/test_schematics.py
@@ -142,7 +142,7 @@ def test_are_random_schematics_preserved_when_reading_and_writing():
             assert write_region.max_schem_z() == read_region.max_schem_z()
 
             # Assert all blocks are equal
-            for x, y, z in write_region.allblockpos():
+            for x, y, z in write_region.block_positions():
                 ws = write_region[x, y, z]
                 rs = read_region[x, y, z]
                 assert ws == rs


### PR DESCRIPTION
Fixes #60.

This PR updates the documentation and library code to use modern snake_case methods and bracket notation, replacing
deprecated camelCase versions.


- **README & docs**: Updated code examples to use `reg[x, y, z]` and snake_case methods.
- **`litemapy`/`schematic.py`**: Updated internal metadata/enclosure calculations.
- **Examples & Tests**: Updated `filter.py` and `test_schematics.py` for consistency.

Verified with `pytest`.