### PR TITLE
Add TileEntity sync to BlockState and Region block access

### DIFF
--- a/docs/source/blocks.rst
+++ b/docs/source/blocks.rst
@@ -15,5 +15,24 @@ E.g.
     >>> "facing" in block
     True
 
+Block states can also carry a :class:`TileEntity` for blocks like chests or hoppers.
+When reading from a region, the tile entity is automatically attached:
+
+.. code-block:: python
+
+    >>> chest = region[x, y, z]
+    >>> chest.tile_entity
+    <TileEntity at (x, y, z)>
+
+When writing to a region, the tile entity is automatically stored:
+
+.. code-block:: python
+
+    >>> from litemapy import BlockState, TileEntity
+    >>> from nbtlib.tag import Compound, String
+    >>> te = TileEntity(Compound({"id": String("minecraft:chest")}))
+    >>> chest = BlockState("minecraft:chest").with_tile_entity(te)
+    >>> region[x, y, z] = chest
+
 .. autoclass:: litemapy.BlockState
     :members:

--- a/litemapy/minecraft.py
+++ b/litemapy/minecraft.py
@@ -23,17 +23,20 @@ class BlockState:
     __block_id: str
     __properties: DiscriminatingDictionary
     __identifier_cache: Optional[str]
+    __tile_entity: Optional['TileEntity']
 
-    def __init__(self, block_id: str, **properties: str) -> None:
+    def __init__(self, block_id: str, tile_entity: Optional['TileEntity'] = None, **properties: str) -> None:
         """
         A block state has a block ID and a dictionary of properties.
 
         :param block_id:    the identifier of the block (e.g. *minecraft:stone*)
+        :param tile_entity: the tile entity associated with this block (e.g. chest inventory)
         :param properties:  the properties of the block state as keyword parameters (e.g. *facing="north"*)
         """
         self.__block_id = assert_valid_identifier(block_id)
         self.__properties = DiscriminatingDictionary(self.__validate, properties)
         self.__identifier_cache = None
+        self.__tile_entity = tile_entity
 
     def to_nbt(self) -> Compound:
         """
@@ -80,7 +83,7 @@ class BlockState:
         :param block_id:  the block id for the new :class:`BlockState`
         """
         assert_valid_identifier(block_id)
-        return BlockState(block_id, **self.__properties)
+        return BlockState(block_id, tile_entity=self.tile_entity, **self.__properties)
 
     def with_properties(self, **properties: Optional[str]) -> 'BlockState':
         """
@@ -92,13 +95,30 @@ class BlockState:
         :returns: A copy of this :class:`BlockState` with the given properties updated to new values
         """
         none_properties = list(map(lambda kv: kv[0], filter(lambda kv: kv[1] is None, properties.items())))
-        other = BlockState(self.id)
+        other = BlockState(self.id, tile_entity=self.tile_entity)
         other.__properties.update(self.__properties)
         for prop_name in none_properties:
             other.__properties.pop(prop_name)
             properties.pop(prop_name)
         other.__properties.update(properties)
         return other
+
+    def with_tile_entity(self, tile_entity: Optional['TileEntity']) -> 'BlockState':
+        """
+        Returns a new copy of this :class:`BlockState` with the given tile entity.
+
+        :param tile_entity: the new tile entity
+
+        :returns: A copy of this :class:`BlockState` with the given tile entity
+        """
+        return BlockState(self.id, tile_entity=tile_entity, **self.__properties)
+
+    @property
+    def tile_entity(self) -> Optional['TileEntity']:
+        """
+        The tile entity associated with this block state.
+        """
+        return self.__tile_entity
 
     def properties(self) -> Iterable[tuple[str, str]]:
         """

--- a/litemapy/schematic.py
+++ b/litemapy/schematic.py
@@ -337,6 +337,7 @@ class Region:
         self.__blocks = np.zeros((abs(width), abs(height), abs(length)), dtype=np.uint32)
         self.__entities = []
         self.__tile_entities = []
+        self.__te_index = {}
         self.__block_ticks = []
         self.__fluid_ticks = []
 
@@ -672,13 +673,17 @@ class Region:
         x, y, z = self.__region_coordinates_to_store_coordinates(*position)
 
         # Remove existing tile entity at this position
-        self.__tile_entities = [te for te in self.__tile_entities if te.position != (x, y, z)]
+        store_pos = (x, y, z)
+        old_te = self.__te_index.pop(store_pos, None)
+        if old_te is not None:
+            self.__tile_entities.remove(old_te)
 
         # Add new tile entity if present in the BlockState
         if block.tile_entity is not None:
             new_te = copy.deepcopy(block.tile_entity)
-            new_te.position = (x, y, z)
+            new_te.position = store_pos
             self.__tile_entities.append(new_te)
+            self.__te_index[store_pos] = new_te
 
         if block in self.__palette:
             i = self.__palette.index(block)
@@ -702,10 +707,9 @@ class Region:
         :returns:           the tile entity at the given position, or None if there is none
         """
         store_pos = self.__region_coordinates_to_store_coordinates(*position)
-        for te in self.__tile_entities:
-            if te.position == store_pos:
-                return te
-        return None
+        if len(self.__te_index) != len(self.__tile_entities):
+            self.__te_index = {te.position: te for te in self.__tile_entities}
+        return self.__te_index.get(store_pos)
 
     @deprecated_name("getblockcount")
     def count_blocks(self) -> int:

--- a/litemapy/schematic.py
+++ b/litemapy/schematic.py
@@ -3,6 +3,7 @@ from time import time
 
 import nbtlib
 import numpy as np
+import copy
 from nbtlib.tag import Short, Byte, Int, Long, Double, String, List, Compound, ByteArray, IntArray
 from typing_extensions import deprecated
 
@@ -657,7 +658,11 @@ class Region:
 
     def __getitem__(self, position: tuple[int, int, int]) -> BlockState:
         x, y, z = self.__region_coordinates_to_store_coordinates(*position)
-        return self.__palette[self.__blocks[x, y, z]]
+        state = self.__palette[self.__blocks[x, y, z]]
+        te = self.get_tile_entity(position)
+        if te is not None:
+            return state.with_tile_entity(te)
+        return state
 
     @deprecated("Region.getblock() is deprecated. Use array style syntax instead: region[x, y, z]")
     def getblock(self, x: int, y: int, z: int) -> BlockState:
@@ -665,6 +670,16 @@ class Region:
 
     def __setitem__(self, position: tuple[int, int, int], block: BlockState) -> None:
         x, y, z = self.__region_coordinates_to_store_coordinates(*position)
+
+        # Remove existing tile entity at this position
+        self.__tile_entities = [te for te in self.__tile_entities if te.position != (x, y, z)]
+
+        # Add new tile entity if present in the BlockState
+        if block.tile_entity is not None:
+            new_te = copy.deepcopy(block.tile_entity)
+            new_te.position = (x, y, z)
+            self.__tile_entities.append(new_te)
+
         if block in self.__palette:
             i = self.__palette.index(block)
         else:
@@ -678,6 +693,19 @@ class Region:
 
     def __contains__(self, block: BlockState) -> bool:
         return block in self.__palette and self.__palette.index(block) in self.__blocks
+
+    def get_tile_entity(self, position: tuple[int, int, int]) -> Optional[TileEntity]:
+        """
+        Returns the tile entity at the given position, if any.
+
+        :param position:    the position to look for a tile entity at
+        :returns:           the tile entity at the given position, or None if there is none
+        """
+        store_pos = self.__region_coordinates_to_store_coordinates(*position)
+        for te in self.__tile_entities:
+            if te.position == store_pos:
+                return te
+        return None
 
     @deprecated_name("getblockcount")
     def count_blocks(self) -> int:

--- a/litemapy/schematic.py
+++ b/litemapy/schematic.py
@@ -672,8 +672,12 @@ class Region:
     def __setitem__(self, position: tuple[int, int, int], block: BlockState) -> None:
         x, y, z = self.__region_coordinates_to_store_coordinates(*position)
 
-        # Remove existing tile entity at this position
+        # Rebuild tile entity index if stale (e.g. after from_nbt appends)
         store_pos = (x, y, z)
+        if len(self.__te_index) != len(self.__tile_entities):
+            self.__te_index = {te.position: te for te in self.__tile_entities}
+
+        # Remove existing tile entity at this position
         old_te = self.__te_index.pop(store_pos, None)
         if old_te is not None:
             self.__tile_entities.remove(old_te)
@@ -685,10 +689,13 @@ class Region:
             self.__tile_entities.append(new_te)
             self.__te_index[store_pos] = new_te
 
-        if block in self.__palette:
-            i = self.__palette.index(block)
+        # Strip tile entity before palette storage to avoid leaking TE
+        # to other blocks sharing the same palette entry
+        palette_block = block.with_tile_entity(None) if block.tile_entity else block
+        if palette_block in self.__palette:
+            i = self.__palette.index(palette_block)
         else:
-            self.__palette.append(block)
+            self.__palette.append(palette_block)
             i = len(self.__palette) - 1
         self.__blocks[x, y, z] = i
 

--- a/tests/test_tile_entity.py
+++ b/tests/test_tile_entity.py
@@ -1,0 +1,161 @@
+from tempfile import TemporaryDirectory
+from os import path
+
+from litemapy import Schematic, Region, BlockState, TileEntity
+from nbtlib.tag import Compound, String, List, Byte
+
+
+def test_tile_entity_copy_on_assignment():
+    reg_a = Region(0, 0, 0, 5, 5, 5)
+    pos_a = (1, 1, 1)
+
+    te_nbt = Compound({
+        "id": String("minecraft:hopper"),
+        "Items": List[Compound]([
+            Compound({
+                "Slot": Byte(0),
+                "id": String("minecraft:diamond"),
+                "Count": Byte(1)
+            })
+        ])
+    })
+    te = TileEntity(te_nbt)
+
+    hopper = BlockState("minecraft:hopper").with_tile_entity(te)
+    reg_a[pos_a] = hopper
+
+    retrieved_a = reg_a[pos_a]
+    assert retrieved_a.id == "minecraft:hopper"
+    assert retrieved_a.tile_entity is not None
+    assert retrieved_a.tile_entity.data["Items"][0]["id"] == "minecraft:diamond"
+
+    reg_b = Region(0, 0, 0, 10, 10, 10)
+    pos_b = (5, 5, 5)
+
+    reg_b[pos_b] = reg_a[pos_a]
+
+    retrieved_b = reg_b[pos_b]
+    assert retrieved_b.id == "minecraft:hopper"
+    assert retrieved_b.tile_entity is not None
+    assert retrieved_b.tile_entity.data["Items"][0]["id"] == "minecraft:diamond"
+    assert retrieved_b.tile_entity.position == pos_b
+    assert int(retrieved_b.tile_entity.data["x"]) == pos_b[0]
+
+    # Verify deep copy
+    reg_a[pos_a].tile_entity.data["Items"][0]["id"] = String("minecraft:dirt")
+    assert reg_b[pos_b].tile_entity.data["Items"][0]["id"] == "minecraft:diamond"
+
+
+def test_tile_entity_removal_on_overwrite():
+    reg = Region(0, 0, 0, 3, 3, 3)
+    pos = (1, 1, 1)
+
+    te = TileEntity(Compound({"id": String("minecraft:hopper")}))
+    reg[pos] = BlockState("minecraft:hopper").with_tile_entity(te)
+    assert len(reg.tile_entities) == 1
+
+    reg[pos] = BlockState("minecraft:air")
+
+    assert len(reg.tile_entities) == 0
+    assert reg[pos].tile_entity is None
+
+
+def test_tile_entity_overwrite_with_another_tile_entity():
+    reg = Region(0, 0, 0, 3, 3, 3)
+    pos = (1, 1, 1)
+
+    te_diamond = TileEntity(Compound({
+        "id": String("minecraft:chest"),
+        "Items": List[Compound]([
+            Compound({"Slot": Byte(0), "id": String("minecraft:diamond"), "Count": Byte(1)})
+        ])
+    }))
+    reg[pos] = BlockState("minecraft:chest").with_tile_entity(te_diamond)
+    assert reg[pos].tile_entity.data["Items"][0]["id"] == "minecraft:diamond"
+
+    te_emerald = TileEntity(Compound({
+        "id": String("minecraft:chest"),
+        "Items": List[Compound]([
+            Compound({"Slot": Byte(0), "id": String("minecraft:emerald"), "Count": Byte(1)})
+        ])
+    }))
+    reg[pos] = BlockState("minecraft:chest").with_tile_entity(te_emerald)
+
+    # Old tile entity should be replaced, not accumulated
+    assert len(reg.tile_entities) == 1
+    assert reg[pos].tile_entity.data["Items"][0]["id"] == "minecraft:emerald"
+
+
+def test_get_tile_entity_returns_none_for_empty_position():
+    reg = Region(0, 0, 0, 3, 3, 3)
+    assert reg.get_tile_entity((0, 0, 0)) is None
+    assert reg[0, 0, 0].tile_entity is None
+
+
+def test_with_id_preserves_tile_entity():
+    te = TileEntity(Compound({
+        "id": String("minecraft:chest"),
+        "Items": List[Compound]([
+            Compound({"Slot": Byte(0), "id": String("minecraft:diamond"), "Count": Byte(1)})
+        ])
+    }))
+    chest = BlockState("minecraft:chest").with_tile_entity(te)
+    barrel = chest.with_id("minecraft:barrel")
+    assert barrel.id == "minecraft:barrel"
+    assert barrel.tile_entity is not None
+    assert barrel.tile_entity.data["Items"][0]["id"] == "minecraft:diamond"
+
+
+def test_with_properties_preserves_tile_entity():
+    te = TileEntity(Compound({"id": String("minecraft:chest")}))
+    chest = BlockState("minecraft:chest", facing="north").with_tile_entity(te)
+    updated = chest.with_properties(facing="south")
+    assert updated["facing"] == "south"
+    assert updated.tile_entity is not None
+
+
+def test_litematic_round_trip_preserves_tile_entities():
+    reg = Region(0, 0, 0, 5, 5, 5)
+
+    te_1 = TileEntity(Compound({
+        "id": String("minecraft:chest"),
+        "Items": List[Compound]([
+            Compound({"Slot": Byte(0), "id": String("minecraft:diamond"), "Count": Byte(64)})
+        ])
+    }))
+    reg[1, 1, 1] = BlockState("minecraft:chest").with_tile_entity(te_1)
+
+    te_2 = TileEntity(Compound({
+        "id": String("minecraft:chest"),
+        "Items": List[Compound]([
+            Compound({"Slot": Byte(0), "id": String("minecraft:emerald"), "Count": Byte(16)})
+        ])
+    }))
+    reg[3, 2, 1] = BlockState("minecraft:chest").with_tile_entity(te_2)
+
+    reg[0, 0, 0] = BlockState("minecraft:stone")
+
+    schem = Schematic(name="te_test", author="test", description="test", regions={"main": reg})
+
+    with TemporaryDirectory() as tmp:
+        file_path = path.join(tmp, "te_test.litematic")
+        schem.save(file_path)
+        loaded = Schematic.load(file_path)
+
+    loaded_reg = loaded.regions["main"]
+    assert len(loaded_reg.tile_entities) == 2
+
+    b1 = loaded_reg[1, 1, 1]
+    assert b1.id == "minecraft:chest"
+    assert b1.tile_entity is not None
+    assert b1.tile_entity.data["Items"][0]["id"] == "minecraft:diamond"
+    assert int(b1.tile_entity.data["Items"][0]["Count"]) == 64
+
+    b2 = loaded_reg[3, 2, 1]
+    assert b2.id == "minecraft:chest"
+    assert b2.tile_entity is not None
+    assert b2.tile_entity.data["Items"][0]["id"] == "minecraft:emerald"
+
+    # Blocks without tile entities should not be affected
+    assert loaded_reg[0, 0, 0].tile_entity is None
+    assert loaded_reg[0, 0, 0].id == "minecraft:stone"

--- a/tests/test_tile_entity.py
+++ b/tests/test_tile_entity.py
@@ -159,3 +159,29 @@ def test_litematic_round_trip_preserves_tile_entities():
     # Blocks without tile entities should not be affected
     assert loaded_reg[0, 0, 0].tile_entity is None
     assert loaded_reg[0, 0, 0].id == "minecraft:stone"
+
+
+def test_palette_does_not_leak_tile_entity():
+    # A TE-bearing block stored first should not leak its TE
+    # to other blocks of the same type that have no TE
+    reg = Region(0, 0, 0, 5, 5, 5)
+
+    te_nbt = Compound({
+        "id": String("minecraft:chest"),
+        "Items": List[Compound]([
+            Compound({
+                "Slot": Byte(0),
+                "id": String("minecraft:diamond"),
+                "Count": Byte(64)
+            })
+        ])
+    })
+    te = TileEntity(te_nbt)
+    chest_with_te = BlockState("minecraft:chest").with_tile_entity(te)
+    chest_without_te = BlockState("minecraft:chest")
+
+    reg[0, 0, 0] = chest_with_te
+    reg[1, 1, 1] = chest_without_te
+
+    assert reg[0, 0, 0].tile_entity is not None
+    assert reg[1, 1, 1].tile_entity is None


### PR DESCRIPTION
## Problem

When reading a Litematica file containing blocks with tile entity data (e.g. chests, hoppers, signs),
modifying the schematic via `region[x, y, z]`, and saving it back, all tile entity data is silently lost.

This is because `__getitem__` returns a `BlockState` with no knowledge of the associated `TileEntity`,
and `__setitem__` does not propagate tile entity information either.

## Changes

### `BlockState` (minecraft.py)
- Added optional `tile_entity` field and read-only property
- Added `with_tile_entity()` method (returns a new instance, does not mutate palette entries)
- `with_id()` / `with_properties()` now preserve the attached tile entity

### `Region` (schematic.py)
- `__getitem__`: attaches the matching `TileEntity` (if any) to the returned `BlockState`
- `__setitem__`: if the assigned `BlockState` carries a `TileEntity`, stores/replaces it in the region;
 if it doesn't, removes any existing TE at that position. Strips TE from the `BlockState` before palette insertion to prevent TE data leaking to other blocks sharing the same palette entry.
- Added `get_tile_entity(x, y, z)` public method
- Added `__te_index` dict cache for O(1) tile entity lookup (lazily rebuilt when the TE list is
 modified externally, e.g. by `from_nbt`). Both `__setitem__` and `get_tile_entity` rebuild the index on cache miss.

### Tests (test_tile_entity.py)
- 8 new tests: copy/assign, removal on overwrite, TE-to-TE overwrite, get_tile_entity returning None, with_id preservation, with_properties preservation, litematic round-trip, palette TE leak regression

### Docs (blocks.rst)
- Added usage examples for reading/writing blocks with tile entities

## Design Notes

- **Palette safety**: `__getitem__` creates a new `BlockState` via `with_tile_entity()` rather than
 mutating the shared palette entry. `__setitem__` strips the tile entity before palette insertion. The palette remains tile-entity-free.
- **Coordinate handling**: TE positions are stored in store coordinates (array indices), consistent
 with `to_structure_nbt` which iterates via `np.ndindex`.
- **Performance**: `get_tile_entity` uses a `dict[(x,y,z) → TileEntity]` index.
 Benchmark: 64³ region with 5000 TEs — full traversal in **0.17s** (vs 56s with linear scan).
- **Backward compatibility**: No changes to existing serialization (`from_nbt`, `to_nbt`, etc.).
 Existing code that doesn't use `tile_entity` is completely unaffected.